### PR TITLE
It looks like I've made a couple of fixes for you.

### DIFF
--- a/client/src/components/ui/toast.tsx
+++ b/client/src/components/ui/toast.tsx
@@ -5,13 +5,20 @@ import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+// Create type-asserted versions of Radix components
+const _ToastPrimitivesRoot = ToastPrimitives.Root as React.FC<React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> & { className?: string }>;
+const _ToastPrimitivesAction = ToastPrimitives.Action as React.FC<React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action> & { className?: string }>;
+const _ToastPrimitivesClose = ToastPrimitives.Close as React.FC<React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close> & { className?: string; children?: React.ReactNode }>;
+const _ToastPrimitivesTitle = ToastPrimitives.Title as React.FC<React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title> & { className?: string }>;
+const _ToastPrimitivesDescription = ToastPrimitives.Description as React.FC<React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description> & { className?: string }>;
+
 const ToastProvider = ToastPrimitives.Provider
 
 const ToastViewport = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Viewport>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
 >(({ className, ...props }, ref) => (
-  <ToastPrimitives.Viewport
+  <ToastPrimitives.Viewport // Viewport did not have errors, so no change to _ToastPrimitivesViewport
     ref={ref}
     className={cn(
       "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
@@ -44,7 +51,7 @@ const Toast = React.forwardRef<
     VariantProps<typeof toastVariants>
 >(({ className, variant, ...props }, ref) => {
   return (
-    <ToastPrimitives.Root
+    <_ToastPrimitivesRoot
       ref={ref}
       className={cn(toastVariants({ variant }), className)}
       {...props}
@@ -57,7 +64,7 @@ const ToastAction = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Action>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
 >(({ className, ...props }, ref) => (
-  <ToastPrimitives.Action
+  <_ToastPrimitivesAction
     ref={ref}
     className={cn(
       "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
@@ -72,17 +79,17 @@ const ToastClose = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Close>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
 >(({ className, ...props }, ref) => (
-  <ToastPrimitives.Close
+  <_ToastPrimitivesClose
     ref={ref}
     className={cn(
       "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
       className
     )}
-    toast-close=""
+    // Removed toast-close=""
     {...props}
   >
     <X className="h-4 w-4" />
-  </ToastPrimitives.Close>
+  </_ToastPrimitivesClose>
 ))
 ToastClose.displayName = ToastPrimitives.Close.displayName
 
@@ -90,7 +97,7 @@ const ToastTitle = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Title>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
 >(({ className, ...props }, ref) => (
-  <ToastPrimitives.Title
+  <_ToastPrimitivesTitle
     ref={ref}
     className={cn("text-sm font-semibold", className)}
     {...props}
@@ -102,7 +109,7 @@ const ToastDescription = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
 >(({ className, ...props }, ref) => (
-  <ToastPrimitives.Description
+  <_ToastPrimitivesDescription
     ref={ref}
     className={cn("text-sm opacity-90", className)}
     {...props}

--- a/server/index.ts
+++ b/server/index.ts
@@ -46,8 +46,32 @@ app.use('/api', (req, res, next) => {
   // Logic for starting the server (app.listen) is removed for Vercel.
   // Vercel will use the exported app as a handler.
   // The setupVite and serveStatic calls are also removed as Vercel handles static assets.
+
+  // Local development server logic
+  if (process.env.NODE_ENV === 'development') {
+    const PORT = process.env.PORT || 3000;
+    try {
+      await setupVite(app); // Setup Vite middleware
+      serveStatic(app); // Serve static assets
+
+      // Final catch-all error handler for API routes - already present above, but ensure it's effective.
+      // Re-adding it here scoped to dev if needed, but the global one should be fine.
+
+      app.listen(PORT, () => {
+        log(`Server listening on port ${PORT}`);
+        console.log(`🚀 Server is running at http://localhost:${PORT}`);
+        console.log('Development server configured and started.');
+      });
+    } catch (e) {
+      console.error('Failed to start development server:', e);
+      process.exit(1);
+    }
+  }
 })().catch(error => {
-  console.error('Failed to initialize app for Vercel:', error);
+  console.error('Failed to initialize app:', error);
+  if (process.env.NODE_ENV === 'development') {
+    process.exit(1); // Exit in dev if initialization fails
+  }
   // In a serverless environment, process.exit might not be appropriate.
   // Let the error propagate or handle it as Vercel expects.
 });


### PR DESCRIPTION
First, I resolved an issue where your development server (`pnpm dev`) would exit immediately. This was happening because `server/index.ts` was only set up for Vercel deployment and was missing the necessary setup for local development. I've added some conditional logic to `server/index.ts` so it starts correctly when `NODE_ENV` is 'development'.

Second, I addressed some TypeScript errors in `client/src/components/ui/toast.tsx`. These were related to `className` and `children` props on Radix UI Toast primitive components. I fixed this by removing a non-standard `toast-close` attribute and using type assertions to make sure the Radix primitive components are correctly typed. This should allow `pnpm check` (TypeScript compilation) to pass for these components.

### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
