### PR TITLE
Fix: Apply type assertions to Radix UI primitives

### DIFF
--- a/client/src/components/ui/accordion.tsx
+++ b/client/src/components/ui/accordion.tsx
@@ -4,13 +4,19 @@ import { ChevronDown } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+// Create type-asserted versions of Radix components
+const _AccordionPrimitiveItem = AccordionPrimitive.Item as React.FC<React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item> & { className?: string }>;
+const _AccordionPrimitiveTrigger = AccordionPrimitive.Trigger as React.FC<React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger> & { className?: string; children?: React.ReactNode }>;
+const _AccordionPrimitiveContent = AccordionPrimitive.Content as React.FC<React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content> & { children?: React.ReactNode; className?: string; }>;
+// Note: AccordionPrimitive.Header is a simple div, assuming it doesn't need className assertion from props.
+
 const Accordion = AccordionPrimitive.Root
 
 const AccordionItem = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
 >(({ className, ...props }, ref) => (
-  <AccordionPrimitive.Item
+  <_AccordionPrimitiveItem
     ref={ref}
     className={cn("border-b", className)}
     {...props}
@@ -22,8 +28,8 @@ const AccordionTrigger = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
 >(({ className, children, ...props }, ref) => (
-  <AccordionPrimitive.Header className="flex">
-    <AccordionPrimitive.Trigger
+  <AccordionPrimitive.Header className="flex"> {/* Header is not asserted as it's not taking className from props */}
+    <_AccordionPrimitiveTrigger
       ref={ref}
       className={cn(
         "flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline [&[data-state=open]>svg]:rotate-180",
@@ -33,7 +39,7 @@ const AccordionTrigger = React.forwardRef<
     >
       {children}
       <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
-    </AccordionPrimitive.Trigger>
+    </_AccordionPrimitiveTrigger>
   </AccordionPrimitive.Header>
 ))
 AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName
@@ -42,13 +48,16 @@ const AccordionContent = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
-  <AccordionPrimitive.Content
+  <_AccordionPrimitiveContent
     ref={ref}
-    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
-    {...props}
+    // The className on _AccordionPrimitiveContent itself is for its own styling, not from the wrapper's className prop in this case.
+    // The wrapper's className is applied to the inner div.
+    // We assert className on _AccordionPrimitiveContent in case it's ever passed via ...props or needed for direct styling.
+    className={cn("overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down", /* if props.className existed, it would be here */)}
+    {...props} // children should be passed correctly via props if not destructured earlier for the primitive
   >
     <div className={cn("pb-4 pt-0", className)}>{children}</div>
-  </AccordionPrimitive.Content>
+  </_AccordionPrimitiveContent>
 ))
 
 AccordionContent.displayName = AccordionPrimitive.Content.displayName

--- a/client/src/components/ui/alert-dialog.tsx
+++ b/client/src/components/ui/alert-dialog.tsx
@@ -4,6 +4,14 @@ import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 import { cn } from "@/lib/utils"
 import { buttonVariants } from "@/components/ui/button"
 
+// Create type-asserted versions of Radix components
+const _AlertDialogPrimitiveOverlay = AlertDialogPrimitive.Overlay as React.FC<React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay> & { className?: string }>;
+const _AlertDialogPrimitiveContent = AlertDialogPrimitive.Content as React.FC<React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content> & { className?: string; children?: React.ReactNode }>;
+const _AlertDialogPrimitiveTitle = AlertDialogPrimitive.Title as React.FC<React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title> & { className?: string; children?: React.ReactNode }>;
+const _AlertDialogPrimitiveDescription = AlertDialogPrimitive.Description as React.FC<React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description> & { className?: string; children?: React.ReactNode }>;
+const _AlertDialogPrimitiveAction = AlertDialogPrimitive.Action as React.FC<React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action> & { className?: string; children?: React.ReactNode }>;
+const _AlertDialogPrimitiveCancel = AlertDialogPrimitive.Cancel as React.FC<React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel> & { className?: string; children?: React.ReactNode }>;
+
 const AlertDialog = AlertDialogPrimitive.Root
 
 const AlertDialogTrigger = AlertDialogPrimitive.Trigger
@@ -14,7 +22,7 @@ const AlertDialogOverlay = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Overlay
+  <_AlertDialogPrimitiveOverlay
     className={cn(
       "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
@@ -30,8 +38,8 @@ const AlertDialogContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
 >(({ className, ...props }, ref) => (
   <AlertDialogPortal>
-    <AlertDialogOverlay />
-    <AlertDialogPrimitive.Content
+    <AlertDialogOverlay /> {/* Uses the already wrapped and exported AlertDialogOverlay */}
+    <_AlertDialogPrimitiveContent
       ref={ref}
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
@@ -75,7 +83,7 @@ const AlertDialogTitle = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Title
+  <_AlertDialogPrimitiveTitle
     ref={ref}
     className={cn("text-lg font-semibold", className)}
     {...props}
@@ -87,7 +95,7 @@ const AlertDialogDescription = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Description
+  <_AlertDialogPrimitiveDescription
     ref={ref}
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
@@ -100,7 +108,7 @@ const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Action
+  <_AlertDialogPrimitiveAction
     ref={ref}
     className={cn(buttonVariants(), className)}
     {...props}
@@ -112,7 +120,7 @@ const AlertDialogCancel = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
 >(({ className, ...props }, ref) => (
-  <AlertDialogPrimitive.Cancel
+  <_AlertDialogPrimitiveCancel
     ref={ref}
     className={cn(
       buttonVariants({ variant: "outline" }),

--- a/client/src/components/ui/avatar.tsx
+++ b/client/src/components/ui/avatar.tsx
@@ -5,11 +5,16 @@ import * as AvatarPrimitive from "@radix-ui/react-avatar"
 
 import { cn } from "@/lib/utils"
 
+// Create type-asserted versions of Radix components
+const _AvatarPrimitiveRoot = AvatarPrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root> & { className?: string }>;
+const _AvatarPrimitiveImage = AvatarPrimitive.Image as React.FC<React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image> & { className?: string }>;
+const _AvatarPrimitiveFallback = AvatarPrimitive.Fallback as React.FC<React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback> & { className?: string }>;
+
 const Avatar = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
 >(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Root
+  <_AvatarPrimitiveRoot
     ref={ref}
     className={cn(
       "relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full",
@@ -24,7 +29,7 @@ const AvatarImage = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Image>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
 >(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Image
+  <_AvatarPrimitiveImage
     ref={ref}
     className={cn("aspect-square h-full w-full", className)}
     {...props}
@@ -36,7 +41,7 @@ const AvatarFallback = React.forwardRef<
   React.ElementRef<typeof AvatarPrimitive.Fallback>,
   React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
 >(({ className, ...props }, ref) => (
-  <AvatarPrimitive.Fallback
+  <_AvatarPrimitiveFallback
     ref={ref}
     className={cn(
       "flex h-full w-full items-center justify-center rounded-full bg-muted",

--- a/client/src/components/ui/checkbox.tsx
+++ b/client/src/components/ui/checkbox.tsx
@@ -4,11 +4,15 @@ import { Check } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+// Create type-asserted versions of Radix components
+const _CheckboxPrimitiveRoot = CheckboxPrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> & { className?: string; children?: React.ReactNode }>;
+const _CheckboxPrimitiveIndicator = CheckboxPrimitive.Indicator as React.FC<React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Indicator> & { className?: string; children?: React.ReactNode }>;
+
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
 >(({ className, ...props }, ref) => (
-  <CheckboxPrimitive.Root
+  <_CheckboxPrimitiveRoot
     ref={ref}
     className={cn(
       "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
@@ -16,12 +20,12 @@ const Checkbox = React.forwardRef<
     )}
     {...props}
   >
-    <CheckboxPrimitive.Indicator
+    <_CheckboxPrimitiveIndicator
       className={cn("flex items-center justify-center text-current")}
     >
       <Check className="h-4 w-4" />
-    </CheckboxPrimitive.Indicator>
-  </CheckboxPrimitive.Root>
+    </_CheckboxPrimitiveIndicator>
+  </_CheckboxPrimitiveRoot>
 ))
 Checkbox.displayName = CheckboxPrimitive.Root.displayName
 

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -6,19 +6,26 @@ import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+// Create type-asserted versions of Radix components
+const _DialogPrimitiveOverlay = DialogPrimitive.Overlay as React.FC<React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay> & { className?: string }>;
+const _DialogPrimitiveContent = DialogPrimitive.Content as React.FC<React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { className?: string; children?: React.ReactNode }>;
+const _DialogPrimitiveClose = DialogPrimitive.Close as React.FC<React.ComponentPropsWithoutRef<typeof DialogPrimitive.Close> & { className?: string; children?: React.ReactNode }>;
+const _DialogPrimitiveTitle = DialogPrimitive.Title as React.FC<React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title> & { className?: string; children?: React.ReactNode }>;
+const _DialogPrimitiveDescription = DialogPrimitive.Description as React.FC<React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description> & { className?: string; children?: React.ReactNode }>;
+
 const Dialog = DialogPrimitive.Root
 
 const DialogTrigger = DialogPrimitive.Trigger
 
 const DialogPortal = DialogPrimitive.Portal
 
-const DialogClose = DialogPrimitive.Close
+const DialogClose = _DialogPrimitiveClose // Export the asserted version if it's intended to be used with className/children directly
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
+  <_DialogPrimitiveOverlay
     ref={ref}
     className={cn(
       "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
@@ -34,8 +41,8 @@ const DialogContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
+    <DialogOverlay /> {/* Uses the already wrapped and exported DialogOverlay */}
+    <_DialogPrimitiveContent
       ref={ref}
       className={cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
@@ -44,11 +51,11 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <_DialogPrimitiveClose className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
+      </_DialogPrimitiveClose>
+    </_DialogPrimitiveContent>
   </DialogPortal>
 ))
 DialogContent.displayName = DialogPrimitive.Content.displayName
@@ -85,7 +92,7 @@ const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
+  <_DialogPrimitiveTitle
     ref={ref}
     className={cn(
       "text-lg font-semibold leading-none tracking-tight",
@@ -100,7 +107,7 @@ const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
+  <_DialogPrimitiveDescription
     ref={ref}
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
@@ -112,7 +119,7 @@ export {
   Dialog,
   DialogPortal,
   DialogOverlay,
-  DialogClose,
+  DialogClose, // Now exports the asserted version
   DialogTrigger,
   DialogContent,
   DialogHeader,

--- a/client/src/components/ui/dropdown-menu.tsx
+++ b/client/src/components/ui/dropdown-menu.tsx
@@ -4,16 +4,22 @@ import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+// Create type-asserted versions of Radix components
+const _DropdownMenuPrimitiveSubTrigger = DropdownMenuPrimitive.SubTrigger as React.FC<React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & { className?: string; children?: React.ReactNode }>;
+const _DropdownMenuPrimitiveSubContent = DropdownMenuPrimitive.SubContent as React.FC<React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent> & { className?: string; children?: React.ReactNode }>;
+const _DropdownMenuPrimitiveContent = DropdownMenuPrimitive.Content as React.FC<React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & { className?: string; children?: React.ReactNode }>;
+const _DropdownMenuPrimitiveItem = DropdownMenuPrimitive.Item as React.FC<React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & { className?: string; children?: React.ReactNode }>;
+const _DropdownMenuPrimitiveCheckboxItem = DropdownMenuPrimitive.CheckboxItem as React.FC<React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem> & { className?: string; children?: React.ReactNode }>;
+const _DropdownMenuPrimitiveRadioItem = DropdownMenuPrimitive.RadioItem as React.FC<React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem> & { className?: string; children?: React.ReactNode }>;
+const _DropdownMenuPrimitiveLabel = DropdownMenuPrimitive.Label as React.FC<React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & { className?: string; children?: React.ReactNode }>;
+const _DropdownMenuPrimitiveSeparator = DropdownMenuPrimitive.Separator as React.FC<React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator> & { className?: string }>;
+const _DropdownMenuPrimitiveItemIndicator = DropdownMenuPrimitive.ItemIndicator as React.FC<React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.ItemIndicator> & { className?: string; children?: React.ReactNode }>;
+
 const DropdownMenu = DropdownMenuPrimitive.Root
-
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
-
 const DropdownMenuGroup = DropdownMenuPrimitive.Group
-
 const DropdownMenuPortal = DropdownMenuPrimitive.Portal
-
 const DropdownMenuSub = DropdownMenuPrimitive.Sub
-
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
 
 const DropdownMenuSubTrigger = React.forwardRef<
@@ -22,7 +28,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
     inset?: boolean
   }
 >(({ className, inset, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubTrigger
+  <_DropdownMenuPrimitiveSubTrigger
     ref={ref}
     className={cn(
       "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -33,7 +39,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   >
     {children}
     <ChevronRight className="ml-auto" />
-  </DropdownMenuPrimitive.SubTrigger>
+  </_DropdownMenuPrimitiveSubTrigger>
 ))
 DropdownMenuSubTrigger.displayName =
   DropdownMenuPrimitive.SubTrigger.displayName
@@ -42,7 +48,7 @@ const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.SubContent
+  <_DropdownMenuPrimitiveSubContent
     ref={ref}
     className={cn(
       "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
@@ -59,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
   <DropdownMenuPrimitive.Portal>
-    <DropdownMenuPrimitive.Content
+    <_DropdownMenuPrimitiveContent
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
@@ -78,7 +84,7 @@ const DropdownMenuItem = React.forwardRef<
     inset?: boolean
   }
 >(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Item
+  <_DropdownMenuPrimitiveItem
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -94,7 +100,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
 >(({ className, children, checked, ...props }, ref) => (
-  <DropdownMenuPrimitive.CheckboxItem
+  <_DropdownMenuPrimitiveCheckboxItem
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
@@ -104,12 +110,12 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
+      <_DropdownMenuPrimitiveItemIndicator>
         <Check className="h-4 w-4" />
-      </DropdownMenuPrimitive.ItemIndicator>
+      </_DropdownMenuPrimitiveItemIndicator>
     </span>
     {children}
-  </DropdownMenuPrimitive.CheckboxItem>
+  </_DropdownMenuPrimitiveCheckboxItem>
 ))
 DropdownMenuCheckboxItem.displayName =
   DropdownMenuPrimitive.CheckboxItem.displayName
@@ -118,7 +124,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
 >(({ className, children, ...props }, ref) => (
-  <DropdownMenuPrimitive.RadioItem
+  <_DropdownMenuPrimitiveRadioItem
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
@@ -127,12 +133,12 @@ const DropdownMenuRadioItem = React.forwardRef<
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
+      <_DropdownMenuPrimitiveItemIndicator>
         <Circle className="h-2 w-2 fill-current" />
-      </DropdownMenuPrimitive.ItemIndicator>
+      </_DropdownMenuPrimitiveItemIndicator>
     </span>
     {children}
-  </DropdownMenuPrimitive.RadioItem>
+  </_DropdownMenuPrimitiveRadioItem>
 ))
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
 
@@ -142,7 +148,7 @@ const DropdownMenuLabel = React.forwardRef<
     inset?: boolean
   }
 >(({ className, inset, ...props }, ref) => (
-  <DropdownMenuPrimitive.Label
+  <_DropdownMenuPrimitiveLabel
     ref={ref}
     className={cn(
       "px-2 py-1.5 text-sm font-semibold",
@@ -158,7 +164,7 @@ const DropdownMenuSeparator = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
 >(({ className, ...props }, ref) => (
-  <DropdownMenuPrimitive.Separator
+  <_DropdownMenuPrimitiveSeparator
     ref={ref}
     className={cn("-mx-1 my-1 h-px bg-muted", className)}
     {...props}


### PR DESCRIPTION
I've resolved widespread TypeScript errors in your UI components stemming from Radix UI primitive types not explicitly including `className` or `children` props in this project's TypeScript environment.

I applied type assertions to the underlying Radix primitives in several shadcn/ui components to ensure these props are correctly typed. This allows the components to be used with `className` for styling and `children` where appropriate without causing TypeScript errors.

Affected and fixed components include:
- client/src/components/ui/toast.tsx
- client/src/components/ui/avatar.tsx
- client/src/components/ui/alert-dialog.tsx
- client/src/components/ui/accordion.tsx
- client/src/components/ui/checkbox.tsx
- client/src/components/ui/dialog.tsx
- client/src/components/ui/dropdown-menu.tsx

This also includes the initial fix for the dev server startup (`server/index.ts`).

### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
