### PR TITLE
Fix: Comprehensive fixes for startup, types, and auth flow

### DIFF
--- a/server/firebase-admin.ts
+++ b/server/firebase-admin.ts
@@ -22,6 +22,11 @@ if (!admin.apps.length) {
     });
   } else {
     // For development without credentials, use project ID only
+    console.warn(
+      'Firebase Admin SDK: Initializing without explicit service account credentials. ' +
+      'Using projectId only. This requires Application Default Credentials to be configured ' +
+      'for Firestore access in this environment, or use of Firebase emulators.'
+    );
     admin.initializeApp({
       projectId: process.env.FIREBASE_PROJECT_ID || 'demo-churchcare',
     });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -22,7 +22,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (error instanceof z.ZodError) {
         return res.status(400).json({ message: "Invalid user data", errors: error.errors });
       }
-      res.status(500).json({ message: "Failed to create user" });
+      console.error("Error in /api/auth/register:", error); // Detailed error logging
+      res.status(500).json({ message: "Failed to create user", error: error instanceof Error ? error.message : "Unknown error" });
     }
   });
 


### PR DESCRIPTION
This commit includes several fixes and improvements:

1.  **Development Server Startup:**
    *   Ensured `server/index.ts` correctly starts the dev server with `app.listen()` and Vite/static serving when `NODE_ENV` is 'development'.

2.  **UI Component Type Assertions:**
    *   Applied type assertions to numerous Radix UI primitive components within the shadcn/ui structure (e.g., Toast, Avatar, Dialog, DropdownMenu, etc.).
    *   This resolves TypeScript errors where `className` or `children` props were not explicitly recognized by the base Radix types in this project's environment.

3.  **Auth Registration Endpoint (500 Error Diagnostics):**
    *   Added detailed error logging to the `/api/auth/register` route in `server/routes.ts`.
    *   Added a warning log to `server/firebase-admin.ts` to indicate if Firebase Admin SDK initializes without explicit service account credentials, guiding towards proper environment setup for local development against live Firestore.

4.  **Client-Side Authentication for API Requests (401 Errors):**
    *   Modified `getAuthHeaders` in `client/src/lib/queryClient.ts` to use a new `getCurrentUserWhenAvailable` helper.
    *   This helper ensures that Firebase auth state is settled and `auth.currentUser` is available before attempting to fetch an ID token, aiming to resolve 401 Unauthorized errors on API calls made immediately after login/registration.

### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
