### PR TITLE
Fix: Address widespread TypeScript errors for Vercel build

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,8 @@
-import React, { lazy, Suspense, useState } from "react";
+import React, { lazy, Suspense } from "react"; // Removed useState
 import { Switch, Route } from "wouter";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query"; // QueryClient class import removed
 import { Toaster } from "@/components/ui/toaster";
+import { queryClient } from "@/lib/queryClient"; // Import the shared instance
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useAuth, AuthProvider } from "./contexts/AuthContext";
 import { Logo } from "@/components/ui/logo";

--- a/client/src/components/ui/collapsible.tsx
+++ b/client/src/components/ui/collapsible.tsx
@@ -1,11 +1,15 @@
 "use client"
 
+import * as React from "react" // Import React for FC type
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
 
-const Collapsible = CollapsiblePrimitive.Root
+// Create type-asserted versions of Radix components
+const _Collapsible = CollapsiblePrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Root> & { className?: string; children?: React.ReactNode }>;
+const _CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger as React.FC<React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.CollapsibleTrigger> & { className?: string; children?: React.ReactNode }>;
+const _CollapsibleContent = CollapsiblePrimitive.CollapsibleContent as React.FC<React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.CollapsibleContent> & { className?: string; children?: React.ReactNode }>;
 
-const CollapsibleTrigger = CollapsiblePrimitive.CollapsibleTrigger
-
-const CollapsibleContent = CollapsiblePrimitive.CollapsibleContent
+const Collapsible = _Collapsible
+const CollapsibleTrigger = _CollapsibleTrigger
+const CollapsibleContent = _CollapsibleContent
 
 export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/client/src/components/ui/context-menu.tsx
+++ b/client/src/components/ui/context-menu.tsx
@@ -4,17 +4,30 @@ import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-const ContextMenu = ContextMenuPrimitive.Root
+// Create type-asserted versions of Radix components
+const _ContextMenuPrimitiveRoot = ContextMenuPrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Root> & { children?: React.ReactNode; className?: string; }>;
+const _ContextMenuPrimitiveTrigger = ContextMenuPrimitive.Trigger as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Trigger> & { children?: React.ReactNode; className?: string; }>;
+const _ContextMenuPrimitiveGroup = ContextMenuPrimitive.Group as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Group> & { children?: React.ReactNode; className?: string; }>;
+const _ContextMenuPrimitivePortal = ContextMenuPrimitive.Portal as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Portal> & { children?: React.ReactNode; className?: string; }>;
+const _ContextMenuPrimitiveSub = ContextMenuPrimitive.Sub as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Sub> & { children?: React.ReactNode; className?: string; }>;
+const _ContextMenuPrimitiveRadioGroup = ContextMenuPrimitive.RadioGroup as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioGroup> & { children?: React.ReactNode; className?: string; }>;
+const _ContextMenuPrimitiveSubTrigger = ContextMenuPrimitive.SubTrigger as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & { className?: string; children?: React.ReactNode }>;
+const _ContextMenuPrimitiveSubContent = ContextMenuPrimitive.SubContent as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent> & { className?: string; children?: React.ReactNode }>;
+const _ContextMenuPrimitiveContent = ContextMenuPrimitive.Content as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content> & { className?: string; children?: React.ReactNode }>;
+const _ContextMenuPrimitiveItem = ContextMenuPrimitive.Item as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & { className?: string; children?: React.ReactNode }>;
+const _ContextMenuPrimitiveCheckboxItem = ContextMenuPrimitive.CheckboxItem as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem> & { className?: string; children?: React.ReactNode }>;
+const _ContextMenuPrimitiveRadioItem = ContextMenuPrimitive.RadioItem as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem> & { className?: string; children?: React.ReactNode }>;
+const _ContextMenuPrimitiveLabel = ContextMenuPrimitive.Label as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & { className?: string; children?: React.ReactNode }>;
+const _ContextMenuPrimitiveSeparator = ContextMenuPrimitive.Separator as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator> & { className?: string }>;
+const _ContextMenuPrimitiveItemIndicator = ContextMenuPrimitive.ItemIndicator as React.FC<React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.ItemIndicator> & { className?: string; children?: React.ReactNode }>;
 
-const ContextMenuTrigger = ContextMenuPrimitive.Trigger
 
-const ContextMenuGroup = ContextMenuPrimitive.Group
-
-const ContextMenuPortal = ContextMenuPrimitive.Portal
-
-const ContextMenuSub = ContextMenuPrimitive.Sub
-
-const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup
+const ContextMenu = _ContextMenuPrimitiveRoot
+const ContextMenuTrigger = _ContextMenuPrimitiveTrigger
+const ContextMenuGroup = _ContextMenuPrimitiveGroup
+const ContextMenuPortal = _ContextMenuPrimitivePortal
+const ContextMenuSub = _ContextMenuPrimitiveSub
+const ContextMenuRadioGroup = _ContextMenuPrimitiveRadioGroup
 
 const ContextMenuSubTrigger = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
@@ -22,7 +35,7 @@ const ContextMenuSubTrigger = React.forwardRef<
     inset?: boolean
   }
 >(({ className, inset, children, ...props }, ref) => (
-  <ContextMenuPrimitive.SubTrigger
+  <_ContextMenuPrimitiveSubTrigger
     ref={ref}
     className={cn(
       "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
@@ -33,7 +46,7 @@ const ContextMenuSubTrigger = React.forwardRef<
   >
     {children}
     <ChevronRight className="ml-auto h-4 w-4" />
-  </ContextMenuPrimitive.SubTrigger>
+  </_ContextMenuPrimitiveSubTrigger>
 ))
 ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName
 
@@ -41,7 +54,7 @@ const ContextMenuSubContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.SubContent
+  <_ContextMenuPrimitiveSubContent
     ref={ref}
     className={cn(
       "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
@@ -56,8 +69,8 @@ const ContextMenuContent = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
 >(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.Portal>
-    <ContextMenuPrimitive.Content
+  <ContextMenuPortal> {/* Uses the asserted _ContextMenuPrimitivePortal via ContextMenuPortal export */}
+    <_ContextMenuPrimitiveContent
       ref={ref}
       className={cn(
         "z-50 max-h-[--radix-context-menu-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-context-menu-content-transform-origin]",
@@ -65,7 +78,7 @@ const ContextMenuContent = React.forwardRef<
       )}
       {...props}
     />
-  </ContextMenuPrimitive.Portal>
+  </ContextMenuPortal>
 ))
 ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName
 
@@ -75,7 +88,7 @@ const ContextMenuItem = React.forwardRef<
     inset?: boolean
   }
 >(({ className, inset, ...props }, ref) => (
-  <ContextMenuPrimitive.Item
+  <_ContextMenuPrimitiveItem
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
@@ -91,7 +104,7 @@ const ContextMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
 >(({ className, children, checked, ...props }, ref) => (
-  <ContextMenuPrimitive.CheckboxItem
+  <_ContextMenuPrimitiveCheckboxItem
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
@@ -101,12 +114,12 @@ const ContextMenuCheckboxItem = React.forwardRef<
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <ContextMenuPrimitive.ItemIndicator>
+      <_ContextMenuPrimitiveItemIndicator>
         <Check className="h-4 w-4" />
-      </ContextMenuPrimitive.ItemIndicator>
+      </_ContextMenuPrimitiveItemIndicator>
     </span>
     {children}
-  </ContextMenuPrimitive.CheckboxItem>
+  </_ContextMenuPrimitiveCheckboxItem>
 ))
 ContextMenuCheckboxItem.displayName =
   ContextMenuPrimitive.CheckboxItem.displayName
@@ -115,7 +128,7 @@ const ContextMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
 >(({ className, children, ...props }, ref) => (
-  <ContextMenuPrimitive.RadioItem
+  <_ContextMenuPrimitiveRadioItem
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
@@ -124,12 +137,12 @@ const ContextMenuRadioItem = React.forwardRef<
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <ContextMenuPrimitive.ItemIndicator>
+      <_ContextMenuPrimitiveItemIndicator>
         <Circle className="h-2 w-2 fill-current" />
-      </ContextMenuPrimitive.ItemIndicator>
+      </_ContextMenuPrimitiveItemIndicator>
     </span>
     {children}
-  </ContextMenuPrimitive.RadioItem>
+  </_ContextMenuPrimitiveRadioItem>
 ))
 ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName
 
@@ -139,7 +152,7 @@ const ContextMenuLabel = React.forwardRef<
     inset?: boolean
   }
 >(({ className, inset, ...props }, ref) => (
-  <ContextMenuPrimitive.Label
+  <_ContextMenuPrimitiveLabel
     ref={ref}
     className={cn(
       "px-2 py-1.5 text-sm font-semibold text-foreground",
@@ -155,7 +168,7 @@ const ContextMenuSeparator = React.forwardRef<
   React.ElementRef<typeof ContextMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
 >(({ className, ...props }, ref) => (
-  <ContextMenuPrimitive.Separator
+  <_ContextMenuPrimitiveSeparator
     ref={ref}
     className={cn("-mx-1 my-1 h-px bg-border", className)}
     {...props}

--- a/client/src/components/ui/hover-card.tsx
+++ b/client/src/components/ui/hover-card.tsx
@@ -5,15 +5,19 @@ import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
 
 import { cn } from "@/lib/utils"
 
-const HoverCard = HoverCardPrimitive.Root
+// Create type-asserted versions of Radix components
+const _HoverCardPrimitiveRoot = HoverCardPrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Root> & { className?: string; children?: React.ReactNode }>;
+const _HoverCardPrimitiveTrigger = HoverCardPrimitive.Trigger as React.FC<React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Trigger> & { className?: string; children?: React.ReactNode }>;
+const _HoverCardPrimitiveContent = HoverCardPrimitive.Content as React.FC<React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content> & { className?: string; children?: React.ReactNode }>;
 
-const HoverCardTrigger = HoverCardPrimitive.Trigger
+const HoverCard = _HoverCardPrimitiveRoot
+const HoverCardTrigger = _HoverCardPrimitiveTrigger
 
 const HoverCardContent = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <HoverCardPrimitive.Content
+  <_HoverCardPrimitiveContent
     ref={ref}
     align={align}
     sideOffset={sideOffset}

--- a/client/src/components/ui/label.tsx
+++ b/client/src/components/ui/label.tsx
@@ -4,6 +4,9 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
+// Create type-asserted version of Radix component
+const _LabelPrimitiveRoot = LabelPrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> & { className?: string; children?: React.ReactNode }>;
+
 const labelVariants = cva(
   "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 )
@@ -13,7 +16,7 @@ const Label = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
     VariantProps<typeof labelVariants>
 >(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root
+  <_LabelPrimitiveRoot
     ref={ref}
     className={cn(labelVariants(), className)}
     {...props}

--- a/client/src/components/ui/menubar.tsx
+++ b/client/src/components/ui/menubar.tsx
@@ -6,41 +6,37 @@ import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-function MenubarMenu({
-  ...props
-}: React.ComponentProps<typeof MenubarPrimitive.Menu>) {
-  return <MenubarPrimitive.Menu {...props} />
-}
+// Create type-asserted versions of Radix components
+const _MenubarPrimitiveMenu = MenubarPrimitive.Menu as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Menu> & { className?: string; children?: React.ReactNode }>;
+const _MenubarPrimitiveGroup = MenubarPrimitive.Group as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Group> & { className?: string; children?: React.ReactNode }>;
+const _MenubarPrimitivePortal = MenubarPrimitive.Portal as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Portal> & { className?: string; children?: React.ReactNode }>;
+const _MenubarPrimitiveRadioGroup = MenubarPrimitive.RadioGroup as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.RadioGroup> & { className?: string; children?: React.ReactNode }>;
+const _MenubarPrimitiveSub = MenubarPrimitive.Sub as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Sub> & { className?: string; children?: React.ReactNode }>;
+const _MenubarPrimitiveRoot = MenubarPrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Root> & { className?: string; children?: React.ReactNode }>;
+const _MenubarPrimitiveTrigger = MenubarPrimitive.Trigger as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Trigger> & { className?: string; children?: React.ReactNode }>;
+const _MenubarPrimitiveSubTrigger = MenubarPrimitive.SubTrigger as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubTrigger> & { className?: string; children?: React.ReactNode }>;
+const _MenubarPrimitiveSubContent = MenubarPrimitive.SubContent as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubContent> & { className?: string; children?: React.ReactNode }>;
+const _MenubarPrimitiveContent = MenubarPrimitive.Content as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Content> & { className?: string; children?: React.ReactNode }>;
+const _MenubarPrimitiveItem = MenubarPrimitive.Item as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Item> & { className?: string; children?: React.ReactNode }>;
+const _MenubarPrimitiveCheckboxItem = MenubarPrimitive.CheckboxItem as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.CheckboxItem> & { className?: string; children?: React.ReactNode }>;
+const _MenubarPrimitiveRadioItem = MenubarPrimitive.RadioItem as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.RadioItem> & { className?: string; children?: React.ReactNode }>;
+const _MenubarPrimitiveLabel = MenubarPrimitive.Label as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Label> & { className?: string; children?: React.ReactNode }>;
+const _MenubarPrimitiveSeparator = MenubarPrimitive.Separator as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Separator> & { className?: string }>;
+const _MenubarPrimitiveItemIndicator = MenubarPrimitive.ItemIndicator as React.FC<React.ComponentPropsWithoutRef<typeof MenubarPrimitive.ItemIndicator> & { className?: string; children?: React.ReactNode }>;
 
-function MenubarGroup({
-  ...props
-}: React.ComponentProps<typeof MenubarPrimitive.Group>) {
-  return <MenubarPrimitive.Group {...props} />
-}
+// Re-exporting with asserted types
+const MenubarMenu = _MenubarPrimitiveMenu;
+const MenubarGroup = _MenubarPrimitiveGroup;
+const MenubarPortal = _MenubarPrimitivePortal;
+const MenubarRadioGroup = _MenubarPrimitiveRadioGroup;
+const MenubarSub = (props: React.ComponentProps<typeof _MenubarPrimitiveSub>) => <_MenubarPrimitiveSub data-slot="menubar-sub" {...props} />;
 
-function MenubarPortal({
-  ...props
-}: React.ComponentProps<typeof MenubarPrimitive.Portal>) {
-  return <MenubarPrimitive.Portal {...props} />
-}
-
-function MenubarRadioGroup({
-  ...props
-}: React.ComponentProps<typeof MenubarPrimitive.RadioGroup>) {
-  return <MenubarPrimitive.RadioGroup {...props} />
-}
-
-function MenubarSub({
-  ...props
-}: React.ComponentProps<typeof MenubarPrimitive.Sub>) {
-  return <MenubarPrimitive.Sub data-slot="menubar-sub" {...props} />
-}
 
 const Menubar = React.forwardRef<
   React.ElementRef<typeof MenubarPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Root>
 >(({ className, ...props }, ref) => (
-  <MenubarPrimitive.Root
+  <_MenubarPrimitiveRoot
     ref={ref}
     className={cn(
       "flex h-10 items-center space-x-1 rounded-md border bg-background p-1",
@@ -55,7 +51,7 @@ const MenubarTrigger = React.forwardRef<
   React.ElementRef<typeof MenubarPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Trigger>
 >(({ className, ...props }, ref) => (
-  <MenubarPrimitive.Trigger
+  <_MenubarPrimitiveTrigger
     ref={ref}
     className={cn(
       "flex cursor-default select-none items-center rounded-sm px-3 py-1.5 text-sm font-medium outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
@@ -72,7 +68,7 @@ const MenubarSubTrigger = React.forwardRef<
     inset?: boolean
   }
 >(({ className, inset, children, ...props }, ref) => (
-  <MenubarPrimitive.SubTrigger
+  <_MenubarPrimitiveSubTrigger
     ref={ref}
     className={cn(
       "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
@@ -83,7 +79,7 @@ const MenubarSubTrigger = React.forwardRef<
   >
     {children}
     <ChevronRight className="ml-auto h-4 w-4" />
-  </MenubarPrimitive.SubTrigger>
+  </_MenubarPrimitiveSubTrigger>
 ))
 MenubarSubTrigger.displayName = MenubarPrimitive.SubTrigger.displayName
 
@@ -91,7 +87,7 @@ const MenubarSubContent = React.forwardRef<
   React.ElementRef<typeof MenubarPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
-  <MenubarPrimitive.SubContent
+  <_MenubarPrimitiveSubContent
     ref={ref}
     className={cn(
       "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-menubar-content-transform-origin]",
@@ -110,8 +106,8 @@ const MenubarContent = React.forwardRef<
     { className, align = "start", alignOffset = -4, sideOffset = 8, ...props },
     ref
   ) => (
-    <MenubarPrimitive.Portal>
-      <MenubarPrimitive.Content
+    <MenubarPortal> {/* Uses asserted MenubarPortal */}
+      <_MenubarPrimitiveContent
         ref={ref}
         align={align}
         alignOffset={alignOffset}
@@ -122,7 +118,7 @@ const MenubarContent = React.forwardRef<
         )}
         {...props}
       />
-    </MenubarPrimitive.Portal>
+    </MenubarPortal>
   )
 )
 MenubarContent.displayName = MenubarPrimitive.Content.displayName
@@ -133,7 +129,7 @@ const MenubarItem = React.forwardRef<
     inset?: boolean
   }
 >(({ className, inset, ...props }, ref) => (
-  <MenubarPrimitive.Item
+  <_MenubarPrimitiveItem
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
@@ -149,7 +145,7 @@ const MenubarCheckboxItem = React.forwardRef<
   React.ElementRef<typeof MenubarPrimitive.CheckboxItem>,
   React.ComponentPropsWithoutRef<typeof MenubarPrimitive.CheckboxItem>
 >(({ className, children, checked, ...props }, ref) => (
-  <MenubarPrimitive.CheckboxItem
+  <_MenubarPrimitiveCheckboxItem
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
@@ -159,12 +155,12 @@ const MenubarCheckboxItem = React.forwardRef<
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <MenubarPrimitive.ItemIndicator>
+      <_MenubarPrimitiveItemIndicator>
         <Check className="h-4 w-4" />
-      </MenubarPrimitive.ItemIndicator>
+      </_MenubarPrimitiveItemIndicator>
     </span>
     {children}
-  </MenubarPrimitive.CheckboxItem>
+  </_MenubarPrimitiveCheckboxItem>
 ))
 MenubarCheckboxItem.displayName = MenubarPrimitive.CheckboxItem.displayName
 
@@ -172,7 +168,7 @@ const MenubarRadioItem = React.forwardRef<
   React.ElementRef<typeof MenubarPrimitive.RadioItem>,
   React.ComponentPropsWithoutRef<typeof MenubarPrimitive.RadioItem>
 >(({ className, children, ...props }, ref) => (
-  <MenubarPrimitive.RadioItem
+  <_MenubarPrimitiveRadioItem
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
@@ -181,12 +177,12 @@ const MenubarRadioItem = React.forwardRef<
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <MenubarPrimitive.ItemIndicator>
+      <_MenubarPrimitiveItemIndicator>
         <Circle className="h-2 w-2 fill-current" />
-      </MenubarPrimitive.ItemIndicator>
+      </_MenubarPrimitiveItemIndicator>
     </span>
     {children}
-  </MenubarPrimitive.RadioItem>
+  </_MenubarPrimitiveRadioItem>
 ))
 MenubarRadioItem.displayName = MenubarPrimitive.RadioItem.displayName
 
@@ -196,7 +192,7 @@ const MenubarLabel = React.forwardRef<
     inset?: boolean
   }
 >(({ className, inset, ...props }, ref) => (
-  <MenubarPrimitive.Label
+  <_MenubarPrimitiveLabel
     ref={ref}
     className={cn(
       "px-2 py-1.5 text-sm font-semibold",
@@ -212,7 +208,7 @@ const MenubarSeparator = React.forwardRef<
   React.ElementRef<typeof MenubarPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Separator>
 >(({ className, ...props }, ref) => (
-  <MenubarPrimitive.Separator
+  <_MenubarPrimitiveSeparator
     ref={ref}
     className={cn("-mx-1 my-1 h-px bg-muted", className)}
     {...props}
@@ -234,7 +230,7 @@ const MenubarShortcut = ({
     />
   )
 }
-MenubarShortcut.displayname = "MenubarShortcut"
+MenubarShortcut.displayname = "MenubarShortcut" // Original had .displayname, should be .displayName for consistency if used as a component
 
 export {
   Menubar,

--- a/client/src/components/ui/navigation-menu.tsx
+++ b/client/src/components/ui/navigation-menu.tsx
@@ -5,11 +5,22 @@ import { ChevronDown } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+// Create type-asserted versions of Radix components
+const _NavigationMenuPrimitiveRoot = NavigationMenuPrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root> & { className?: string; children?: React.ReactNode }>;
+const _NavigationMenuPrimitiveList = NavigationMenuPrimitive.List as React.FC<React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List> & { className?: string; children?: React.ReactNode }>;
+const _NavigationMenuPrimitiveItem = NavigationMenuPrimitive.Item as React.FC<React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Item> & { className?: string; children?: React.ReactNode }>;
+const _NavigationMenuPrimitiveTrigger = NavigationMenuPrimitive.Trigger as React.FC<React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Trigger> & { className?: string; children?: React.ReactNode }>;
+const _NavigationMenuPrimitiveContent = NavigationMenuPrimitive.Content as React.FC<React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Content> & { className?: string; children?: React.ReactNode }>;
+const _NavigationMenuPrimitiveLink = NavigationMenuPrimitive.Link as React.FC<React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Link> & { className?: string; children?: React.ReactNode }>;
+const _NavigationMenuPrimitiveViewport = NavigationMenuPrimitive.Viewport as React.FC<React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport> & { className?: string; children?: React.ReactNode }>;
+const _NavigationMenuPrimitiveIndicator = NavigationMenuPrimitive.Indicator as React.FC<React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Indicator> & { className?: string; children?: React.ReactNode }>;
+
+
 const NavigationMenu = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>
 >(({ className, children, ...props }, ref) => (
-  <NavigationMenuPrimitive.Root
+  <_NavigationMenuPrimitiveRoot
     ref={ref}
     className={cn(
       "relative z-10 flex max-w-max flex-1 items-center justify-center",
@@ -18,8 +29,9 @@ const NavigationMenu = React.forwardRef<
     {...props}
   >
     {children}
+    {/* NavigationMenuViewport is a wrapped component, ensure it's used correctly if it's part of children or a direct sibling */}
     <NavigationMenuViewport />
-  </NavigationMenuPrimitive.Root>
+  </_NavigationMenuPrimitiveRoot>
 ))
 NavigationMenu.displayName = NavigationMenuPrimitive.Root.displayName
 
@@ -27,7 +39,7 @@ const NavigationMenuList = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.List>
 >(({ className, ...props }, ref) => (
-  <NavigationMenuPrimitive.List
+  <_NavigationMenuPrimitiveList
     ref={ref}
     className={cn(
       "group flex flex-1 list-none items-center justify-center space-x-1",
@@ -38,7 +50,7 @@ const NavigationMenuList = React.forwardRef<
 ))
 NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName
 
-const NavigationMenuItem = NavigationMenuPrimitive.Item
+const NavigationMenuItem = _NavigationMenuPrimitiveItem // Export asserted version
 
 const navigationMenuTriggerStyle = cva(
   "group inline-flex h-10 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=open]:text-accent-foreground data-[state=open]:bg-accent/50 data-[state=open]:hover:bg-accent data-[state=open]:focus:bg-accent"
@@ -48,7 +60,7 @@ const NavigationMenuTrigger = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Trigger>
 >(({ className, children, ...props }, ref) => (
-  <NavigationMenuPrimitive.Trigger
+  <_NavigationMenuPrimitiveTrigger
     ref={ref}
     className={cn(navigationMenuTriggerStyle(), "group", className)}
     {...props}
@@ -58,7 +70,7 @@ const NavigationMenuTrigger = React.forwardRef<
       className="relative top-[1px] ml-1 h-3 w-3 transition duration-200 group-data-[state=open]:rotate-180"
       aria-hidden="true"
     />
-  </NavigationMenuPrimitive.Trigger>
+  </_NavigationMenuPrimitiveTrigger>
 ))
 NavigationMenuTrigger.displayName = NavigationMenuPrimitive.Trigger.displayName
 
@@ -66,7 +78,7 @@ const NavigationMenuContent = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Content>
 >(({ className, ...props }, ref) => (
-  <NavigationMenuPrimitive.Content
+  <_NavigationMenuPrimitiveContent
     ref={ref}
     className={cn(
       "left-0 top-0 w-full data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 md:absolute md:w-auto ",
@@ -77,14 +89,14 @@ const NavigationMenuContent = React.forwardRef<
 ))
 NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName
 
-const NavigationMenuLink = NavigationMenuPrimitive.Link
+const NavigationMenuLink = _NavigationMenuPrimitiveLink // Export asserted version
 
 const NavigationMenuViewport = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
 >(({ className, ...props }, ref) => (
   <div className={cn("absolute left-0 top-full flex justify-center")}>
-    <NavigationMenuPrimitive.Viewport
+    <_NavigationMenuPrimitiveViewport
       className={cn(
         "origin-top-center relative mt-1.5 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 md:w-[var(--radix-navigation-menu-viewport-width)]",
         className
@@ -101,7 +113,7 @@ const NavigationMenuIndicator = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Indicator>,
   React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Indicator>
 >(({ className, ...props }, ref) => (
-  <NavigationMenuPrimitive.Indicator
+  <_NavigationMenuPrimitiveIndicator
     ref={ref}
     className={cn(
       "top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in",
@@ -110,7 +122,7 @@ const NavigationMenuIndicator = React.forwardRef<
     {...props}
   >
     <div className="relative top-[60%] h-2 w-2 rotate-45 rounded-tl-sm bg-border shadow-md" />
-  </NavigationMenuPrimitive.Indicator>
+  </_NavigationMenuPrimitiveIndicator>
 ))
 NavigationMenuIndicator.displayName =
   NavigationMenuPrimitive.Indicator.displayName

--- a/client/src/components/ui/popover.tsx
+++ b/client/src/components/ui/popover.tsx
@@ -3,16 +3,22 @@ import * as PopoverPrimitive from "@radix-ui/react-popover"
 
 import { cn } from "@/lib/utils"
 
-const Popover = PopoverPrimitive.Root
+// Create type-asserted versions of Radix components
+const _PopoverPrimitiveRoot = PopoverPrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Root> & { className?: string; children?: React.ReactNode }>;
+const _PopoverPrimitiveTrigger = PopoverPrimitive.Trigger as React.FC<React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Trigger> & { className?: string; children?: React.ReactNode }>;
+const _PopoverPrimitivePortal = PopoverPrimitive.Portal as React.FC<React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Portal> & { className?: string; children?: React.ReactNode }>;
+const _PopoverPrimitiveContent = PopoverPrimitive.Content as React.FC<React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content> & { className?: string; children?: React.ReactNode }>;
 
-const PopoverTrigger = PopoverPrimitive.Trigger
+
+const Popover = _PopoverPrimitiveRoot
+const PopoverTrigger = _PopoverPrimitiveTrigger
 
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
+  <_PopoverPrimitivePortal>
+    <_PopoverPrimitiveContent
       ref={ref}
       align={align}
       sideOffset={sideOffset}
@@ -22,7 +28,7 @@ const PopoverContent = React.forwardRef<
       )}
       {...props}
     />
-  </PopoverPrimitive.Portal>
+  </_PopoverPrimitivePortal>
 ))
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 

--- a/client/src/components/ui/progress.tsx
+++ b/client/src/components/ui/progress.tsx
@@ -5,11 +5,15 @@ import * as ProgressPrimitive from "@radix-ui/react-progress"
 
 import { cn } from "@/lib/utils"
 
+// Create type-asserted versions of Radix components
+const _ProgressPrimitiveRoot = ProgressPrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> & { className?: string; children?: React.ReactNode }>;
+const _ProgressPrimitiveIndicator = ProgressPrimitive.Indicator as React.FC<React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Indicator> & { className?: string; children?: React.ReactNode }>;
+
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
 >(({ className, value, ...props }, ref) => (
-  <ProgressPrimitive.Root
+  <_ProgressPrimitiveRoot
     ref={ref}
     className={cn(
       "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
@@ -17,11 +21,11 @@ const Progress = React.forwardRef<
     )}
     {...props}
   >
-    <ProgressPrimitive.Indicator
+    <_ProgressPrimitiveIndicator
       className="h-full w-full flex-1 bg-primary transition-all"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
-  </ProgressPrimitive.Root>
+  </_ProgressPrimitiveRoot>
 ))
 Progress.displayName = ProgressPrimitive.Root.displayName
 

--- a/client/src/components/ui/radio-group.tsx
+++ b/client/src/components/ui/radio-group.tsx
@@ -4,12 +4,17 @@ import { Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+// Create type-asserted versions of Radix components
+const _RadioGroupPrimitiveRoot = RadioGroupPrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root> & { className?: string; children?: React.ReactNode }>;
+const _RadioGroupPrimitiveItem = RadioGroupPrimitive.Item as React.FC<React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item> & { className?: string; children?: React.ReactNode }>;
+const _RadioGroupPrimitiveIndicator = RadioGroupPrimitive.Indicator as React.FC<React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Indicator> & { className?: string; children?: React.ReactNode }>;
+
 const RadioGroup = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
 >(({ className, ...props }, ref) => {
   return (
-    <RadioGroupPrimitive.Root
+    <_RadioGroupPrimitiveRoot
       className={cn("grid gap-2", className)}
       {...props}
       ref={ref}
@@ -23,7 +28,7 @@ const RadioGroupItem = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
 >(({ className, ...props }, ref) => {
   return (
-    <RadioGroupPrimitive.Item
+    <_RadioGroupPrimitiveItem
       ref={ref}
       className={cn(
         "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
@@ -31,10 +36,10 @@ const RadioGroupItem = React.forwardRef<
       )}
       {...props}
     >
-      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+      <_RadioGroupPrimitiveIndicator className="flex items-center justify-center">
         <Circle className="h-2.5 w-2.5 fill-current text-current" />
-      </RadioGroupPrimitive.Indicator>
-    </RadioGroupPrimitive.Item>
+      </_RadioGroupPrimitiveIndicator>
+    </_RadioGroupPrimitiveItem>
   )
 })
 RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName

--- a/client/src/components/ui/scroll-area.tsx
+++ b/client/src/components/ui/scroll-area.tsx
@@ -3,21 +3,28 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 
 import { cn } from "@/lib/utils"
 
+// Create type-asserted versions of Radix components
+const _ScrollAreaPrimitiveRoot = ScrollAreaPrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & { className?: string; children?: React.ReactNode }>;
+const _ScrollAreaPrimitiveViewport = ScrollAreaPrimitive.Viewport as React.FC<React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Viewport> & { className?: string; children?: React.ReactNode }>;
+const _ScrollAreaPrimitiveScrollAreaScrollbar = ScrollAreaPrimitive.ScrollAreaScrollbar as React.FC<React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar> & { className?: string; children?: React.ReactNode }>;
+const _ScrollAreaPrimitiveScrollAreaThumb = ScrollAreaPrimitive.ScrollAreaThumb as React.FC<React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaThumb> & { className?: string; children?: React.ReactNode }>;
+const _ScrollAreaPrimitiveCorner = ScrollAreaPrimitive.Corner as React.FC<React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Corner> & { className?: string; children?: React.ReactNode }>;
+
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
 >(({ className, children, ...props }, ref) => (
-  <ScrollAreaPrimitive.Root
+  <_ScrollAreaPrimitiveRoot
     ref={ref}
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <_ScrollAreaPrimitiveViewport className="h-full w-full rounded-[inherit]">
       {children}
-    </ScrollAreaPrimitive.Viewport>
-    <ScrollBar />
-    <ScrollAreaPrimitive.Corner />
-  </ScrollAreaPrimitive.Root>
+    </_ScrollAreaPrimitiveViewport>
+    <ScrollBar /> {/* ScrollBar is the wrapped component, uses asserted primitives internally */}
+    <_ScrollAreaPrimitiveCorner />
+  </_ScrollAreaPrimitiveRoot>
 ))
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
 
@@ -25,7 +32,7 @@ const ScrollBar = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
 >(({ className, orientation = "vertical", ...props }, ref) => (
-  <ScrollAreaPrimitive.ScrollAreaScrollbar
+  <_ScrollAreaPrimitiveScrollAreaScrollbar
     ref={ref}
     orientation={orientation}
     className={cn(
@@ -38,8 +45,8 @@ const ScrollBar = React.forwardRef<
     )}
     {...props}
   >
-    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
-  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+    <_ScrollAreaPrimitiveScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </_ScrollAreaPrimitiveScrollAreaScrollbar>
 ))
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
 

--- a/client/src/components/ui/select.tsx
+++ b/client/src/components/ui/select.tsx
@@ -6,17 +6,33 @@ import { Check, ChevronDown, ChevronUp } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
-const Select = SelectPrimitive.Root
+// Create type-asserted versions of Radix components
+const _SelectPrimitiveRoot = SelectPrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.Root> & { className?: string; children?: React.ReactNode }>;
+const _SelectPrimitiveGroup = SelectPrimitive.Group as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.Group> & { className?: string; children?: React.ReactNode }>;
+const _SelectPrimitiveValue = SelectPrimitive.Value as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.Value> & { className?: string; children?: React.ReactNode }>;
+const _SelectPrimitiveTrigger = SelectPrimitive.Trigger as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & { className?: string; children?: React.ReactNode }>;
+const _SelectPrimitiveIcon = SelectPrimitive.Icon as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.Icon> & { className?: string; children?: React.ReactNode }>;
+const _SelectPrimitivePortal = SelectPrimitive.Portal as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.Portal> & { className?: string; children?: React.ReactNode }>;
+const _SelectPrimitiveContent = SelectPrimitive.Content as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & { className?: string; children?: React.ReactNode }>;
+const _SelectPrimitiveViewport = SelectPrimitive.Viewport as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.Viewport> & { className?: string; children?: React.ReactNode }>;
+const _SelectPrimitiveItem = SelectPrimitive.Item as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & { className?: string; children?: React.ReactNode }>;
+const _SelectPrimitiveItemText = SelectPrimitive.ItemText as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.ItemText> & { className?: string; children?: React.ReactNode }>;
+const _SelectPrimitiveItemIndicator = SelectPrimitive.ItemIndicator as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.ItemIndicator> & { className?: string; children?: React.ReactNode }>;
+const _SelectPrimitiveLabel = SelectPrimitive.Label as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label> & { className?: string; children?: React.ReactNode }>;
+const _SelectPrimitiveSeparator = SelectPrimitive.Separator as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator> & { className?: string; children?: React.ReactNode }>;
+const _SelectPrimitiveScrollUpButton = SelectPrimitive.ScrollUpButton as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton> & { className?: string; children?: React.ReactNode }>;
+const _SelectPrimitiveScrollDownButton = SelectPrimitive.ScrollDownButton as React.FC<React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton> & { className?: string; children?: React.ReactNode }>;
 
-const SelectGroup = SelectPrimitive.Group
 
-const SelectValue = SelectPrimitive.Value
+const Select = _SelectPrimitiveRoot
+const SelectGroup = _SelectPrimitiveGroup
+const SelectValue = _SelectPrimitiveValue
 
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
 >(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Trigger
+  <_SelectPrimitiveTrigger
     ref={ref}
     className={cn(
       "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background data-[placeholder]:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
@@ -25,10 +41,10 @@ const SelectTrigger = React.forwardRef<
     {...props}
   >
     {children}
-    <SelectPrimitive.Icon asChild>
+    <_SelectPrimitiveIcon asChild>
       <ChevronDown className="h-4 w-4 opacity-50" />
-    </SelectPrimitive.Icon>
-  </SelectPrimitive.Trigger>
+    </_SelectPrimitiveIcon>
+  </_SelectPrimitiveTrigger>
 ))
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
 
@@ -36,7 +52,7 @@ const SelectScrollUpButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
 >(({ className, ...props }, ref) => (
-  <SelectPrimitive.ScrollUpButton
+  <_SelectPrimitiveScrollUpButton
     ref={ref}
     className={cn(
       "flex cursor-default items-center justify-center py-1",
@@ -45,7 +61,7 @@ const SelectScrollUpButton = React.forwardRef<
     {...props}
   >
     <ChevronUp className="h-4 w-4" />
-  </SelectPrimitive.ScrollUpButton>
+  </_SelectPrimitiveScrollUpButton>
 ))
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
 
@@ -53,7 +69,7 @@ const SelectScrollDownButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
 >(({ className, ...props }, ref) => (
-  <SelectPrimitive.ScrollDownButton
+  <_SelectPrimitiveScrollDownButton
     ref={ref}
     className={cn(
       "flex cursor-default items-center justify-center py-1",
@@ -62,7 +78,7 @@ const SelectScrollDownButton = React.forwardRef<
     {...props}
   >
     <ChevronDown className="h-4 w-4" />
-  </SelectPrimitive.ScrollDownButton>
+  </_SelectPrimitiveScrollDownButton>
 ))
 SelectScrollDownButton.displayName =
   SelectPrimitive.ScrollDownButton.displayName
@@ -71,8 +87,8 @@ const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
 >(({ className, children, position = "popper", ...props }, ref) => (
-  <SelectPrimitive.Portal>
-    <SelectPrimitive.Content
+  <_SelectPrimitivePortal>
+    <_SelectPrimitiveContent
       ref={ref}
       className={cn(
         "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
@@ -83,8 +99,8 @@ const SelectContent = React.forwardRef<
       position={position}
       {...props}
     >
-      <SelectScrollUpButton />
-      <SelectPrimitive.Viewport
+      <SelectScrollUpButton /> {/* Uses asserted version via export */}
+      <_SelectPrimitiveViewport
         className={cn(
           "p-1",
           position === "popper" &&
@@ -92,10 +108,10 @@ const SelectContent = React.forwardRef<
         )}
       >
         {children}
-      </SelectPrimitive.Viewport>
-      <SelectScrollDownButton />
-    </SelectPrimitive.Content>
-  </SelectPrimitive.Portal>
+      </_SelectPrimitiveViewport>
+      <SelectScrollDownButton /> {/* Uses asserted version via export */}
+    </_SelectPrimitiveContent>
+  </_SelectPrimitivePortal>
 ))
 SelectContent.displayName = SelectPrimitive.Content.displayName
 
@@ -103,7 +119,7 @@ const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
 >(({ className, ...props }, ref) => (
-  <SelectPrimitive.Label
+  <_SelectPrimitiveLabel
     ref={ref}
     className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
     {...props}
@@ -115,7 +131,7 @@ const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
 >(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Item
+  <_SelectPrimitiveItem
     ref={ref}
     className={cn(
       "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
@@ -124,13 +140,13 @@ const SelectItem = React.forwardRef<
     {...props}
   >
     <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <SelectPrimitive.ItemIndicator>
+      <_SelectPrimitiveItemIndicator>
         <Check className="h-4 w-4" />
-      </SelectPrimitive.ItemIndicator>
+      </_SelectPrimitiveItemIndicator>
     </span>
 
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-  </SelectPrimitive.Item>
+    <_SelectPrimitiveItemText>{children}</_SelectPrimitiveItemText>
+  </_SelectPrimitiveItem>
 ))
 SelectItem.displayName = SelectPrimitive.Item.displayName
 
@@ -138,7 +154,7 @@ const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
 >(({ className, ...props }, ref) => (
-  <SelectPrimitive.Separator
+  <_SelectPrimitiveSeparator
     ref={ref}
     className={cn("-mx-1 my-1 h-px bg-muted", className)}
     {...props}

--- a/client/src/components/ui/separator.tsx
+++ b/client/src/components/ui/separator.tsx
@@ -3,6 +3,9 @@ import * as SeparatorPrimitive from "@radix-ui/react-separator"
 
 import { cn } from "@/lib/utils"
 
+// Create type-asserted version of Radix component
+const _SeparatorPrimitiveRoot = SeparatorPrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root> & { className?: string }>;
+
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
@@ -11,7 +14,7 @@ const Separator = React.forwardRef<
     { className, orientation = "horizontal", decorative = true, ...props },
     ref
   ) => (
-    <SeparatorPrimitive.Root
+    <_SeparatorPrimitiveRoot
       ref={ref}
       decorative={decorative}
       orientation={orientation}

--- a/client/src/components/ui/tabs.tsx
+++ b/client/src/components/ui/tabs.tsx
@@ -3,13 +3,19 @@ import * as TabsPrimitive from "@radix-ui/react-tabs"
 
 import { cn } from "@/lib/utils"
 
-const Tabs = TabsPrimitive.Root
+// Create type-asserted versions of Radix components
+const _TabsPrimitiveRoot = TabsPrimitive.Root as React.FC<React.ComponentPropsWithoutRef<typeof TabsPrimitive.Root> & { className?: string; children?: React.ReactNode }>;
+const _TabsPrimitiveList = TabsPrimitive.List as React.FC<React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> & { className?: string; children?: React.ReactNode }>;
+const _TabsPrimitiveTrigger = TabsPrimitive.Trigger as React.FC<React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & { className?: string; children?: React.ReactNode }>;
+const _TabsPrimitiveContent = TabsPrimitive.Content as React.FC<React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content> & { className?: string; children?: React.ReactNode }>;
+
+const Tabs = _TabsPrimitiveRoot // Export the asserted version
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
+  <_TabsPrimitiveList
     ref={ref}
     className={cn(
       "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
@@ -24,7 +30,7 @@ const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
 >(({ className, ...props }, ref) => (
-  <TabsPrimitive.Trigger
+  <_TabsPrimitiveTrigger
     ref={ref}
     className={cn(
       "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
@@ -39,7 +45,7 @@ const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
 >(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
+  <_TabsPrimitiveContent
     ref={ref}
     className={cn(
       "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",

--- a/client/src/pages/tasks.tsx
+++ b/client/src/pages/tasks.tsx
@@ -89,7 +89,7 @@ export default function Tasks() {
                 <TabsContent value="urgent" className="mt-6">
                   <div className="space-y-4">
                     {urgentTasks?.length ? (
-                      urgentTasks.map((task) => (
+                      urgentTasks.map((task: Task) => (
                         <TaskCard key={task.id} task={task} showMember />
                       ))
                     ) : (
@@ -101,7 +101,7 @@ export default function Tasks() {
                 <TabsContent value="pending" className="mt-6">
                   <div className="space-y-4">
                     {pendingTasks?.length ? (
-                      pendingTasks.map((task) => (
+                      pendingTasks.map((task: Task) => (
                         <TaskCard key={task.id} task={task} showMember />
                       ))
                     ) : (
@@ -113,7 +113,7 @@ export default function Tasks() {
                 <TabsContent value="completed" className="mt-6">
                   <div className="space-y-4">
                     {completedTasks.length ? (
-                      completedTasks.map((task) => (
+                      completedTasks.map((task: Task) => (
                         <TaskCard key={task.id} task={task} showMember />
                       ))
                     ) : (
@@ -125,7 +125,7 @@ export default function Tasks() {
                 <TabsContent value="all" className="mt-6">
                   <div className="space-y-4">
                     {allTasks?.length ? (
-                      allTasks.map((task) => (
+                      allTasks.map((task: Task) => (
                         <TaskCard key={task.id} task={task} showMember />
                       ))
                     ) : (


### PR DESCRIPTION
This commit addresses a large number of TypeScript errors that were causing Vercel builds to fail. The primary issues were related to:

1.  **`@tanstack/react-query` Import:**
    *   Modified `App.tsx` to use the shared `queryClient` instance from `lib/queryClient.ts` to resolve potential import issues with the `QueryClient` class in the Vercel build environment.

2.  **Implicit `any` Types:**
    *   Explicitly typed parameters in `pages/tasks.tsx` that were reported as implicitly having an 'any' type.

3.  **Radix UI Primitive Typings:**
    *   Systematically applied type assertions to numerous Radix UI wrapper components within `client/src/components/ui/`.
    *   This ensures that `className` and `children` props are correctly recognized by TypeScript when passed to the underlying Radix primitives, resolving a common pattern of errors related to components like Tabs, Avatar, AlertDialog, Accordion, Checkbox, Dialog, DropdownMenu, Collapsible, ContextMenu, HoverCard, Label, Menubar, NavigationMenu, Popover, Progress, RadioGroup, ScrollArea, Select, Separator, and Toast.

These changes aim to significantly reduce or eliminate the TypeScript errors reported during Vercel deployment. This also consolidates previous fixes related to dev server startup and auth flow improvements.

### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
