### PR TITLE
Fix: Use vite dev for development server

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development node api/index.cjs",
+    "dev": "vite dev",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outfile=api/index.js --external:firebase-admin",
     "start": "cross-env NODE_ENV=production node api/index.js",
     "vercel-build": "pnpm build",


### PR DESCRIPTION
I updated the dev script in package.json to use `vite dev` instead of directly running the Vercel serverless function. This allows the Vite development server to handle local development, which is the correct approach for a Vite-based project.

I also ensured dependencies are installed so the `vite` command is available.

### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
