### PR TITLE
Fix: Update vercel.json to correctly build frontend and API

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,13 @@
   "version": 2,
   "builds": [
     {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
+    },
+    {
       "src": "api/index.js",
       "use": "@vercel/node"
     }


### PR DESCRIPTION
The previous vercel.json configuration was only specifying the API build and was missing instructions for building the Vite frontend.

This change updates `vercel.json` to:
- Use `@vercel/static-build` targeting `package.json`. This will execute the project's build script (`pnpm build` or `pnpm vercel-build`), which builds both the Vite frontend (to the root `dist/` directory) and the esbuild API (to `api/index.js`).
- Specify `distDir: "dist"` for `@vercel/static-build`.
- Keep the existing `@vercel/node` rule for the now correctly generated `api/index.js`.
- Maintain the routing rules for the SPA and API.

This should resolve the 404 errors by ensuring all parts of the application are built and served correctly by Vercel.

### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
