### PR TITLE
Fix: Add placeholder for missing API routes in server/index.ts

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -19,5 +19,27 @@ app.get('/api/users', async (req, res) => {
   }
 });
 
+// --- ADDED PLACEHOLDER ROUTE ---
+app.get('/api/stats', async (req, res) => {
+  try {
+    // TODO: Replace with actual logic to fetch stats
+    const placeholderStats = {
+      totalMembers: 0,
+      activeTasks: 0,
+      completedTasks: 0,
+    };
+    res.status(200).json(placeholderStats);
+  } catch (error: any) {
+    console.error('Error fetching /api/stats:', error); // Log the error server-side
+    res.status(500).json({ error: 'Failed to fetch stats' });
+  }
+});
+
+// TODO: Add other missing routes here, for example:
+// app.get('/api/tasks/urgent', async (req, res) => { /* ... your logic ... */ });
+// app.get('/api/members', async (req, res) => { /* ... your logic ... */ });
+// app.get('/api/members/recent', async (req, res) => { /* ... your logic ... */ });
+// etc.
+
 // Vercel will use this exported app
 export default app;


### PR DESCRIPTION
API requests were resulting in 404 errors because the corresponding routes (e.g., /api/stats, /api/tasks/urgent) were not defined in the Express app within `server/index.ts`.

This commit adds a placeholder definition for the `/api/stats` route to illustrate the required fix. Other missing API routes need to be similarly defined with their actual business logic.

The `vercel.json` configuration correctly routes `/api/*` requests to the Express app; the issue was internal to the app's routing table.

### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
