### PR TITLE
Feat: Add generic placeholder routes for missing API endpoints

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -19,5 +19,51 @@ app.get('/api/users', async (req, res) => {
   }
 });
 
+// --- EXISTING PLACEHOLDER ROUTE (adjusted for consistency) ---
+app.get('/api/stats', async (req, res) => {
+  try {
+    // TODO: Replace with actual logic to fetch stats
+    console.log(`GET /api/stats called`);
+    res.status(200).json({ message: "Endpoint /api/stats reached successfully", data: { totalMembers: 0, activeTasks: 0, completedTasks: 0 } });
+  } catch (error: any) {
+    console.error('Error in /api/stats:', error);
+    res.status(500).json({ error: 'Failed to process /api/stats' });
+  }
+});
+
+// --- ADDED GENERIC PLACEHOLDER ROUTES ---
+app.get('/api/tasks/urgent', async (req, res) => {
+  try {
+    // TODO: Replace with actual logic to fetch urgent tasks
+    console.log(`GET /api/tasks/urgent called`);
+    res.status(200).json({ message: "Endpoint /api/tasks/urgent reached successfully", data: [] });
+  } catch (error: any) {
+    console.error('Error in /api/tasks/urgent:', error);
+    res.status(500).json({ error: 'Failed to process /api/tasks/urgent' });
+  }
+});
+
+app.get('/api/members', async (req, res) => {
+  try {
+    // TODO: Replace with actual logic to fetch members
+    console.log(`GET /api/members called`);
+    res.status(200).json({ message: "Endpoint /api/members reached successfully", data: [] });
+  } catch (error: any) {
+    console.error('Error in /api/members:', error);
+    res.status(500).json({ error: 'Failed to process /api/members' });
+  }
+});
+
+app.get('/api/members/recent', async (req, res) => {
+  try {
+    // TODO: Replace with actual logic to fetch recent members
+    console.log(`GET /api/members/recent called`);
+    res.status(200).json({ message: "Endpoint /api/members/recent reached successfully", data: [] });
+  } catch (error: any) {
+    console.error('Error in /api/members/recent:', error);
+    res.status(500).json({ error: 'Failed to process /api/members/recent' });
+  }
+});
+
 // Vercel will use this exported app
 export default app;

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,13 @@
   "version": 2,
   "builds": [
     {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
+    },
+    {
       "src": "api/index.js",
       "use": "@vercel/node"
     }


### PR DESCRIPTION
Adds generic placeholder handlers in `server/index.ts` for the following previously missing API routes:
- GET /api/tasks/urgent
- GET /api/members
- GET /api/members/recent

The existing placeholder for GET /api/stats was also updated for consistency.

These placeholders return a 200 OK status with a simple JSON message and a basic data structure. This is intended to resolve the 404 errors encountered by the frontend and allow pages to load.

The actual business logic for these endpoints still needs to be implemented by replacing these placeholders.

### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
