### PR TITLE
fix: Add queryFn to useQuery in members page

### DIFF
--- a/client/src/pages/members.tsx
+++ b/client/src/pages/members.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { Loader2, UserPlus, Search } from "lucide-react";
+import { apiRequest } from "@/lib/api";
 import { useAuth } from "@/contexts/AuthContext";
 import DesktopSidebar from "@/components/layout/desktop-sidebar";
 import MobileHeader from "@/components/layout/mobile-header";
@@ -40,6 +41,7 @@ export default function Members() {
 
   const { data: members, isLoading } = useQuery<Member[]>({
     queryKey: ["/api/members"],
+    queryFn: () => apiRequest("GET", "/api/members"),
     enabled: !!currentUser,
   });
 


### PR DESCRIPTION
This commit fixes a bug where the members page would crash due to a TypeError. The `useQuery` hook in `client/src/pages/members.tsx` was missing a `queryFn`, which caused the `members` variable to be `undefined` and resulted in an error when trying to filter it.

This commit adds the `queryFn` to the `useQuery` hook, which fetches the members from the API and resolves the error.

### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
