### PR TITLE
fix: Remove static build configuration from vercel.json

### DIFF
--- a/client/src/pages/members.tsx
+++ b/client/src/pages/members.tsx
@@ -39,9 +39,7 @@ export default function Members() {
   const [searchTerm, setSearchTerm] = useState("");
   const { currentUser } = useAuth();
 
-
   console.log("currentUser", currentUser);
-
 
   const { data: members, isLoading, error } = useQuery<Member[]>({
     queryKey: ["/api/members"],

--- a/vercel.json
+++ b/vercel.json
@@ -2,13 +2,6 @@
   "version": 2,
   "builds": [
     {
-      "src": "package.json",
-      "use": "@vercel/static-build",
-      "config": {
-        "distDir": "dist"
-      }
-    },
-    {
       "src": "api/index.js",
       "use": "@vercel/node"
     }


### PR DESCRIPTION
This commit removes the static build configuration from the `vercel.json` file. This will allow Vercel to automatically detect that this is a Vite project and use the correct build command.

### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
