### PR TITLE
Fix(server): Exclude manifest.json from auth

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
       "dest": "/api/index.js"
     },
     {
+      "src": "/manifest.json",
+      "dest": "/manifest.json"
+    },
+    {
       "handle": "filesystem"
     },
     {


### PR DESCRIPTION
- Added a new route to `vercel.json` to handle the `manifest.json` file separately.
- This prevents the `manifest.json` file from being handled by the catch-all route and served as `index.html`, which was causing a 401 authentication error.

### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
