### PR TITLE
Fix(frontend): Wrap wouter Link component child

### DIFF
--- a/client/src/components/layout/desktop-sidebar.tsx
+++ b/client/src/components/layout/desktop-sidebar.tsx
@@ -28,22 +28,24 @@ export default function DesktopSidebar() {
           {navigation.map((item) => {
             const Icon = item.icon;
             return (
-              <Link key={item.name} href={item.href} className={`flex items-center space-x-3 px-4 py-3 rounded-lg font-medium transition-colors ${
-                item.current
-                  ? 'text-blue-600 bg-blue-50'
-                  : 'text-gray-600 hover:text-blue-600 hover:bg-gray-50'
-              }`}>
-                <Icon className="w-5 h-5" />
-                <span>{item.name}</span>
-                {item.badge && (
-                  <span className={`text-xs rounded-full px-2 py-1 ml-auto ${
-                    item.notification
-                      ? 'bg-amber-600 text-white notification-badge'
-                      : 'bg-green-600 text-white'
-                  }`}>
-                    {item.badge}
-                  </span>
-                )}
+              <Link key={item.name} href={item.href}>
+                <span className={`flex items-center space-x-3 px-4 py-3 rounded-lg font-medium transition-colors ${
+                  item.current
+                    ? 'text-blue-600 bg-blue-50'
+                    : 'text-gray-600 hover:text-blue-600 hover:bg-gray-50'
+                }`}>
+                  <Icon className="w-5 h-5" />
+                  <span>{item.name}</span>
+                  {item.badge && (
+                    <span className={`text-xs rounded-full px-2 py-1 ml-auto ${
+                      item.notification
+                        ? 'bg-amber-600 text-white notification-badge'
+                        : 'bg-green-600 text-white'
+                    }`}>
+                      {item.badge}
+                    </span>
+                  )}
+                </span>
               </Link>
             );
           })}

--- a/client/src/components/layout/mobile-navigation.tsx
+++ b/client/src/components/layout/mobile-navigation.tsx
@@ -22,20 +22,22 @@ export default function MobileNavigation({ activeTab }: MobileNavigationProps) {
           const isActive = activeTab === item.id;
           
           return (
-            <Link key={item.name} href={item.href} className={`flex flex-col items-center space-y-1 p-2 relative ${
-              isActive ? 'text-blue-600' : 'text-gray-600 hover:text-blue-600'
-            }`}>
-              <Icon className="w-6 h-6" />
-              <span className="text-xs font-medium">{item.name}</span>
-              {item.badge && (
-                <span className={`absolute -top-1 -right-1 text-xs rounded-full w-5 h-5 flex items-center justify-center ${
-                  item.notification
-                    ? 'bg-amber-600 text-white notification-badge'
-                    : 'bg-green-600 text-white'
-                }`}>
-                  {item.badge}
-                </span>
-              )}
+            <Link key={item.name} href={item.href}>
+              <span className={`flex flex-col items-center space-y-1 p-2 relative ${
+                isActive ? 'text-blue-600' : 'text-gray-600 hover:text-blue-600'
+              }`}>
+                <Icon className="w-6 h-6" />
+                <span className="text-xs font-medium">{item.name}</span>
+                {item.badge && (
+                  <span className={`absolute -top-1 -right-1 text-xs rounded-full w-5 h-5 flex items-center justify-center ${
+                    item.notification
+                      ? 'bg-amber-600 text-white notification-badge'
+                      : 'bg-green-600 text-white'
+                  }`}>
+                    {item.badge}
+                  </span>
+                )}
+              </span>
             </Link>
           );
         })}


### PR DESCRIPTION
- I wrapped the content of the `Link` component in a `span` in `mobile-navigation.tsx` and `desktop-sidebar.tsx`.
- This ensures that the `Link` component has a single child element, which should resolve the `(i || []) is not iterable` error.

### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
