### PR TITLE
Fix(server): Handle static assets in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
       "dest": "/api/index.js"
     },
     {
+      "src": "/assets/(.*)",
+      "dest": "/assets/$1"
+    },
+    {
       "src": "/manifest.json",
       "dest": "/manifest.json"
     },


### PR DESCRIPTION
- Added a new route to `vercel.json` to correctly handle static assets in the `/assets` directory.
- This prevents the server from sending `index.html` when a JavaScript module is requested, which was causing a MIME type error.

### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
