### PR TITLE
Fix: Correct Vercel configuration to resolve MIME type error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,28 +1,22 @@
 {
   "version": 2,
-  
-  "routes": [
+  "builds": [
     {
-      "src": "/api/(.*)",
-      "dest": "/api/index.js"
-    },
-    {
-      "src": "/assets/(.*)",
-      "dest": "/assets/$1"
-    },
-    {
-      "src": "/manifest.json",
-      "dest": "/manifest.json"
-    },
-    {
-      "handle": "filesystem"
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "dist"
+      }
     }
   ],
-  "env": {
-    "NODE_ENV": "production"
-  }
+  "rewrites": [
+    {
+      "source": "/api/(.*)",
+      "destination": "/api"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
 }


### PR DESCRIPTION
The previous Vercel configuration was causing a MIME type mismatch by serving `index.html` for all requests, including JavaScript modules. This change updates `vercel.json` to correctly serve static assets from the `dist` directory and handle client-side routing, resolving the issue where the app would show a blank screen due to a persistence error.

### What does this PR do?

### Description of Task to be completed

### How should this be manually tested?

### What are the relevant issues this PR belongs to

#<NUMBER>

### Any background context you want to add?

### Screenshots (Optional)
